### PR TITLE
Test stm32 adc fixes - 2/2

### DIFF
--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -437,7 +437,7 @@ void HAL_adc_start_conversion(const uint8_t adc_pin) {
       case POWER_MONITOR_VOLTAGE_PIN: pin_index = POWERMON_VOLTS; break;
     #endif
   }
-  HAL_adc_result = HAL_adc_results[(int)pin_index] >> (12 - HAL_ADC_RESOLUTION); // shift out unused bits
+  HAL_adc_result = (HAL_adc_results[(int)pin_index] & 0xFFF) >> (12 - HAL_ADC_RESOLUTION); // shift out unused bits
 }
 
 uint16_t HAL_adc_get_result() { return HAL_adc_result; }

--- a/ini/stm32-common.ini
+++ b/ini/stm32-common.ini
@@ -17,7 +17,6 @@ build_flags      = ${common.build_flags}
                    -DUSBCON -DUSBD_USE_CDC
                    -DTIM_IRQ_PRIO=13
                    -DADC_RESOLUTION=12
-                   -DADC_RESOLUTION=12
 build_unflags    = -std=gnu++11
 src_filter       = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/backtrace>
 extra_scripts    = ${common.extra_scripts}

--- a/ini/stm32-common.ini
+++ b/ini/stm32-common.ini
@@ -16,6 +16,8 @@ build_flags      = ${common.build_flags}
                    -std=gnu++14 -DHAL_STM32
                    -DUSBCON -DUSBD_USE_CDC
                    -DTIM_IRQ_PRIO=13
+                   -DADC_RESOLUTION=12
+                   -DADC_RESOLUTION=12
 build_unflags    = -std=gnu++11
 src_filter       = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/backtrace>
 extra_scripts    = ${common.extra_scripts}


### PR DESCRIPTION
Finishes the changes started with pull request #6.
Applies corrective commit cherry-picked from Marlin release 2.0.9.3, to correct inadvertent errors in the initial ADC change.  Restores bit filtering to reduce noise from top 4 bits in 16 bit word used for 12bit ADC resolution.
Restores conditional ADC resolution which was inadvertently defaulting to 10 bits.